### PR TITLE
Fix: unable to drag slider in playground - removed overflow-hidden fr…

### DIFF
--- a/playground.html
+++ b/playground.html
@@ -11,13 +11,13 @@
     <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@400;500;600&display=swap" rel="stylesheet">
 </head>
 
-<body class="bg-black text-white p-4 h-screen">
+<body class="bg-black text-white p-4 h-screen overflow-hidden">
 
     <div class="flex flex-col h-full" id="mainContainer">
         <div id="editorContainer"
-            class="draggable-block rounded-lg overflow-hidden shadow-lg border border-green-500 border-opacity-30 flex-1"
+            class="draggable-block rounded-lg shadow-lg border border-green-500 border-opacity-30 flex-1 flex flex-col"
             style="min-height: 0;">
-            <div class="header-drag-handle bg-black bg-opacity-60 backdrop-blur-lg px-4 py-2 border-b border-green-500 border-opacity-30 flex items-center cursor-move transition-all duration-300 hover:bg-opacity-80 hover:border-opacity-60"
+            <div class="header-drag-handle bg-black bg-opacity-60 backdrop-blur-lg px-4 py-2 border-b border-green-500 border-opacity-30 flex items-center cursor-move transition-all duration-300 hover:bg-opacity-80 hover:border-opacity-60 flex-shrink-0"
                 id="editorHeader">
                 <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 text-green-400" fill="none" viewBox="0 0 24 24"
                     stroke="currentColor">
@@ -26,7 +26,7 @@
                 </svg>
                 <span class="text-green-400">script.js</span>
             </div>
-            <div id="editor" class="h-[calc(100%-40px)]"></div>
+            <div id="editor" class="flex-1 overflow-hidden"></div>
         </div>
 
         <div id="dragHandle"
@@ -34,9 +34,9 @@
             style="margin: 8px 0;"></div>
 
         <div id="consoleContainer"
-            class="draggable-block rounded-lg overflow-hidden shadow-lg border border-green-500 border-opacity-30 flex-1"
+            class="draggable-block rounded-lg shadow-lg border border-green-500 border-opacity-30 flex-1 flex flex-col"
             style="min-height: 0;">
-            <div class="header-drag-handle bg-black bg-opacity-60 backdrop-blur-lg px-4 border-b border-green-500 border-opacity-30 flex justify-between items-center cursor-move hover:bg-opacity-80 hover:border-opacity-60"
+            <div class="header-drag-handle bg-black bg-opacity-60 backdrop-blur-lg px-4 border-b border-green-500 border-opacity-30 flex justify-between items-center cursor-move hover:bg-opacity-80 hover:border-opacity-60 flex-shrink-0"
                 id="consoleHeader">
                 <div class="flex items-center">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-4 w-4 mr-2 text-green-400" fill="none" viewBox="0 0 24 24"
@@ -57,7 +57,7 @@
                     </button>
                 </div>
             </div>
-            <div id="consoleOutput" class="p-3 overflow-auto h-[calc(100%-40px)]"></div>
+            <div id="consoleOutput" class="p-3 overflow-auto flex-1"></div>
         </div>
     </div>
 


### PR DESCRIPTION
Fixes #2

## 🐛 Problem
The drag slider between the editor and console panels was non-functional, preventing users from resizing the panels. This was caused by `overflow-hidden` classes on the containers blocking proper layout and interaction.

## ✨ Changes Made
- Removed `overflow-hidden` class from editor and console containers to allow proper flex layout
- Restructured containers with `flex flex-col` for correct parent-child relationships
- Added `flex-shrink-0` to headers to prevent them from collapsing
- Updated editor div to use `flex-1 overflow-hidden` (Monaco handles internal scrolling)
- Updated console output to use `flex-1` with `overflow-auto` for independent scrolling
- Added `overflow-hidden` to body element to prevent page-level scrolling

## 🧪 Testing
- ✅ Drag slider now works smoothly - panels resize correctly
- ✅ Editor scrolling functions properly (Monaco's built-in behavior)
- ✅ Console output scrolls independently within its container
- ✅ No unwanted scrolling outside designated areas

## 📸 Before & After

### Before ❌
<img width="1923" alt="Before: Drag slider non-functional" src="https://github.com/user-attachments/assets/a40e40ae-e567-4da2-86d7-bae7f1a49d02" />

*Drag handle was unresponsive - could not resize panels*

### After ✅
<img width="1925" alt="After: Drag slider working perfectly" src="https://github.com/user-attachments/assets/0899162c-c549-4b67-8d6f-c8b0dfcbbe87" />

*Drag handle is now fully functional - smooth panel resizing*

---

**Note:** This fix addresses the "unable to drag slider" portion of issue #2. The mobile responsiveness aspect may require additional work.